### PR TITLE
add best-effort constant-time scalar-mul

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add separate best-effort constant-time scalar mul
 - restructure into two sub-modules: `hashes` and `algebra`.
 - impl Baby JubJub curve using `TwistedEdwardsCurve` abstraction
 - add `TwistedEdwardsCurve` abstraction

--- a/src/algebra/curve.ts
+++ b/src/algebra/curve.ts
@@ -233,7 +233,8 @@ export class TwistedEdwardsCurve<FieldElement>
     return res;
   }
 
-  // return a if bit is 0, b otherwise
+  // return a if bit is 0, b if 1
+  // caller must ensure that bit is 0 or 1
   private sel(
     bit: number,
     a: AffinePoint<FieldElement>,

--- a/src/algebra/field.ts
+++ b/src/algebra/field.ts
@@ -13,6 +13,7 @@ export interface PrimeField<FieldElement> {
   Two: FieldElement;
 
   fromString(str: string): FieldElement;
+  fromBigint(n: bigint): FieldElement;
   toString(element: FieldElement): string;
 
   fromBytes(bytes: Uint8Array): FieldElement;
@@ -88,6 +89,10 @@ export class ZModPField implements PrimeField<bigint> {
   fromBytes(bytes: Uint8Array): bigint {
     const hex = "0x" + uint8ArrayToUnprefixedHex(bytes);
     return this.reduce(BigInt(hex));
+  }
+
+  fromBigint(n: bigint): bigint {
+    return this.reduce(n);
   }
 
   toBytes(element: bigint): Uint8Array {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,3 +35,13 @@ export function bigintToBits(value: bigint): boolean[] {
 
   return bits;
 }
+
+export function bigintToBitsNum(value: bigint): number[] {
+  const bits: number[] = [];
+  while (value > 0n) {
+    bits.push(Number(value & 1n));
+    value >>= 1n;
+  }
+
+  return bits;
+}

--- a/test/babyJubJub.test.ts
+++ b/test/babyJubJub.test.ts
@@ -83,6 +83,21 @@ describe("BabyJubJub", () => {
     });
   });
 
+  it("scalarMulVartime matches circomlibjs", () => {
+    range(10).forEach(() => {
+      const point = randomSubgroupPoint();
+      const pointCircom = [point.x, point.y];
+
+      const scalar = randomBigintModP(BabyJubJub.PrimeSubgroupOrder);
+
+      const expected = babyjub.mulPointEscalar(pointCircom, scalar);
+      const got = BabyJubJub.scalarMulVartime(point, scalar);
+
+      expect(got.x).to.equal(expected[0]);
+      expect(got.y).to.equal(expected[1]);
+    });
+  });
+
   it("toString matches fromString", () => {
     range(10).forEach(() => {
       const point = randomSubgroupPoint();


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.
-->

## Motivation

- scalar mul not constant-time
- while we are working with javascript bigints here (JIT, etc), still good to have best-effort / at least try to reduce timing variance

## Solution

- rename existing `scalarMul` method `scalarMulVartime`
- add new `scalarMul` method using double-always-add method from here: https://www.hyperelliptic.org/tanja/teaching/crypto21/ecc-8.pdf

## PR Checklist

- [x] Added Tests
- [x] Updated CHANGELOG.md